### PR TITLE
Remove bounding boxes and replace with msg specific fields

### DIFF
--- a/soccer_vision_msgs/msg/Ball.msg
+++ b/soccer_vision_msgs/msg/Ball.msg
@@ -2,11 +2,10 @@
 
 float32 CONFIDENCE_UNKNOWN=-1
 
-# A bounding box that surrounds the ball in the image, this does not have to include
-# the whole ball, but only the part of the ball that was detected.
-vision_msgs/BoundingBox2D bb
+# Diameter of the ball (in pixels)
+float32 diameter
 
-# Center point of the ball, the z-axis should be ignored (in pixel)
+# Center point of the ball, the z-axis should be ignored (in pixels)
 geometry_msgs/Point center
 
 # A confidence rating between 0 and 1, or -1(CONFIDENCE_UNKNOWN) by default.

--- a/soccer_vision_msgs/msg/FieldBoundary.msg
+++ b/soccer_vision_msgs/msg/FieldBoundary.msg
@@ -10,7 +10,7 @@ std_msgs/Header header
 # The points along the field boundary detected in the image, are stored as a line strip.
 # You can think of the field boundary as a line between every two consecutive points,
 # so 0-1, 1-2, 2-3, 3-4, 4-5...
-geometry_msgs/Point[] points # 2D points (in pixel)
+geometry_msgs/Point[] points # 2D points (in pixels)
 
 # A confidence rating between 0 and 1, or -1(CONFIDENCE_UNKNOWN) by default.
 # 0 - field boundary detection module is 0% sure it is a field boundary.

--- a/soccer_vision_msgs/msg/Goalpost.msg
+++ b/soccer_vision_msgs/msg/Goalpost.msg
@@ -10,18 +10,13 @@ uint8 TEAM_OPPONENT=2
 
 float32 CONFIDENCE_UNKNOWN=-1
 
-# A bounding box that surrounds the goalpost in the image.
-# This does not have to include the whole goalpost, but only the 
-# part of the goalpost that was detected.
-vision_msgs/BoundingBox2D bb
-
 # Top and bottom points defining the significant axis of the post.
 # The z-axis should be ignored.
 # The points should be located at the centre along the width of the post.
 geometry_msgs/Point top
 geometry_msgs/Point bottom
 
-# Orthogonal to significant vector (in pixel)
+# Orthogonal to significant vector (in pixels)
 float32 width
 
 # Whether the post is a left or right post, when looking INTO the goal.

--- a/soccer_vision_msgs/msg/MarkingEllipse.msg
+++ b/soccer_vision_msgs/msg/MarkingEllipse.msg
@@ -2,12 +2,14 @@
 
 float32 CONFIDENCE_UNKNOWN=-1
 
-# A bounding box that surrounds the ellipse in the image, this does not have to include
-# the whole ellipse, but only the part of the ellipse that was detected.
-vision_msgs/BoundingBox2D bb
-
-# Center point of the ellipse, the z-axis should be ignored (in pixel)
+# Center point of the ellipse, the z-axis should be ignored (in pixels)
 geometry_msgs/Point center
+
+# Width of the ellipse (in pixels)
+float32 width
+
+# Height of the ellipse (in pixels)
+float32 height
 
 # A confidence rating between 0 and 1, or -1(CONFIDENCE_UNKNOWN) by default.
 # 0 - ellipse detection module is 0% sure it is a ellipse.

--- a/soccer_vision_msgs/msg/MarkingIntersection.msg
+++ b/soccer_vision_msgs/msg/MarkingIntersection.msg
@@ -9,7 +9,7 @@
 
 float32 CONFIDENCE_UNKNOWN=-1
 
-# Center point of the intersection, the z-axis should be ignored (in pixel)
+# Center point of the intersection, the z-axis should be ignored (in pixels)
 geometry_msgs/Point center
 
 # The number of rays outgoing from an intersection. This is 3 for a T-Junction and 

--- a/soccer_vision_msgs/msg/MarkingSegment.msg
+++ b/soccer_vision_msgs/msg/MarkingSegment.msg
@@ -9,6 +9,11 @@ float32 CONFIDENCE_UNKNOWN=-1
 geometry_msgs/Point start
 geometry_msgs/Point end
 
+# Width of segment at the start and end points. The width is defined as the number of
+# pixels perpendicular to the segment, that the segment occupies.
+float32 start_width
+float32 end_width
+
 # A confidence rating between 0 and 1, or -1(CONFIDENCE_UNKNOWN) by default.
 # 0 - segment detection module is 0% sure it is a segment.
 # 1 - segment detection module is 100% sure it is a segment.


### PR DESCRIPTION
I had Bounding Box information initially so that it's easy to visualize the detections, but I think such attributes that seem to almost be purely for "debugging", can be published on a separate topic with a BoundingBox2d array msg.

For example, with Ball.msg, I expect having the diameter is more useful than having the bounding box, for modules that would be listening to the msg.