### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/build_and_test_foxy.yaml
+++ b/.github/workflows/build_and_test_foxy.yaml
@@ -24,8 +24,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
-      - uses: ros-tooling/setup-ros@v0.2
+      - uses: ros-tooling/setup-ros@v0.3
       - uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: foxy

--- a/.github/workflows/build_and_test_galactic.yaml
+++ b/.github/workflows/build_and_test_galactic.yaml
@@ -24,8 +24,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
-      - uses: ros-tooling/setup-ros@v0.2
+      - uses: ros-tooling/setup-ros@v0.3
       - uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: galactic

--- a/.github/workflows/build_and_test_rolling.yaml
+++ b/.github/workflows/build_and_test_rolling.yaml
@@ -21,6 +21,8 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    container:
+      image: ubuntu:jammy
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/build_and_test_rolling.yaml
+++ b/.github/workflows/build_and_test_rolling.yaml
@@ -24,8 +24,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
-      - uses: ros-tooling/setup-ros@v0.2
+      - uses: ros-tooling/setup-ros@v0.3
       - uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: rolling


### PR DESCRIPTION
* Removes `actions/checkout@v2` which is not needed for this package's CI.
* Updates `setup-ros` to v0.3, the new release made recently.

Although ROS2 Rolling is still not passing, due to [this issue](https://answers.ros.org/question/397168/no-rule-to-make-target-usrlibx86_64-linux-gnulibpython39so/), this PR is still an improvement to get one step closer for it to work.