### PR TITLE
use branch names when querying for CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,24 @@ A set of packages which contain common soccer interface files
 [![Build and Test (foxy)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_foxy.yaml/badge.svg?branch=galactic)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_foxy.yaml?query=branch:galactic)
 [![Build and Test (galactic)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_galactic.yaml/badge.svg?branch=galactic)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_galactic.yaml?query=branch:galactic)
 [![Build and Test (rolling)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_rolling.yaml/badge.svg?branch=rolling)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_rolling.yaml?query=branch:rolling)
+
+## Installation
+
+### For ROS2 Rolling
+
+Only source installation is available. Run the following in your ROS workspace:
+
+```
+git clone https://github.com/ros-sports/soccer_interfaces.git src/soccer_interfaces
+vcs import src < src/soccer_interfaces/dependencies.repos
+colcon build --allow-overriding vision_msgs
+```
+
+### For ROS2 Foxy and Galactic
+
+Only source installation is available. Run the following in your ROS workspace:
+
+```
+git clone https://github.com/ros-sports/soccer_interfaces.git src/soccer_interfaces --branch galactic
+colcon build
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # soccer_interfaces
 A set of packages which contain common soccer interface files
 
-[![Build and Test (foxy)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_foxy.yaml/badge.svg)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_foxy.yaml)
-[![Build and Test (galactic)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_galactic.yaml/badge.svg)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_galactic.yaml)
-[![Build and Test (rolling)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_rolling.yaml/badge.svg)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_rolling.yaml)
+[![Build and Test (foxy)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_foxy.yaml/badge.svg?branch=galactic)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_foxy.yaml?query=branch:galactic)
+[![Build and Test (galactic)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_galactic.yaml/badge.svg?branch=galactic)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_galactic.yaml?query=branch:galactic)
+[![Build and Test (rolling)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_rolling.yaml/badge.svg?branch=rolling)](https://github.com/ros-sports/soccer_interfaces/actions/workflows/build_and_test_rolling.yaml?query=branch:rolling)


### PR DESCRIPTION
Despite galactic branching off from rolling, the README file in rolling must display the CI status of the galactic branch, and instructions on how to build the galactic branch.

This PR will be backported into the galactic branch too.