### PR TITLE
Remove building of vision_msgs from source

### DIFF
--- a/.github/workflows/build_and_test_rolling.yaml
+++ b/.github/workflows/build_and_test_rolling.yaml
@@ -26,9 +26,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v2
       - uses: ros-tooling/setup-ros@v0.3
       - uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: rolling
-          vcs-repo-file-url: dependencies.repos

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Only source installation is available. Run the following in your ROS workspace:
 
 ```
 git clone https://github.com/ros-sports/soccer_interfaces.git src/soccer_interfaces
-vcs import src < src/soccer_interfaces/dependencies.repos
 colcon build --allow-overriding vision_msgs
 ```
 

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,5 +1,0 @@
-repositories:
-  vision_msgs:
-    type: git
-    url: https://github.com/ros-perception/vision_msgs.git
-    version: ros2


### PR DESCRIPTION
No need to build vision_msgs from source anymore, since ros2 rolling sync happened yesterday: https://discourse.ros.org/t/new-packages-for-ros-2-rolling-ridley-2022-03-24/24830

Resolves: #24

Signed-off-by: Kenji Brameld <kenjibrameld@gmail.com>