### PR TITLE
add build_and_test_foxy and build_and_test_galactic to rolling branch

### DIFF
--- a/.github/workflows/build_and_test_foxy.yaml
+++ b/.github/workflows/build_and_test_foxy.yaml
@@ -1,0 +1,30 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Build and Test (foxy)
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push
+  push:
+    branches: [ galactic ]
+
+  # Triggers the workflow on pull requests
+  pull_request:
+    branches: [ galactic ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: ros-tooling/setup-ros@v0.3
+      - uses: ros-tooling/action-ros-ci@v0.2
+        with:
+          target-ros2-distro: foxy

--- a/.github/workflows/build_and_test_galactic.yaml
+++ b/.github/workflows/build_and_test_galactic.yaml
@@ -1,0 +1,30 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Build and Test (galactic)
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push
+  push:
+    branches: [ galactic ]
+
+  # Triggers the workflow on pull requests
+  pull_request:
+    branches: [ galactic ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: ros-tooling/setup-ros@v0.3
+      - uses: ros-tooling/action-ros-ci@v0.2
+        with:
+          target-ros2-distro: galactic


### PR DESCRIPTION
Add ``build_and_test_foxy.yaml`` and ``build_and_test_galactic.yaml`` to the default rolling branch. I removed these two files when I split off the galactic branch, but it seems like they are necessary for Github to recognise the actions even exist.

Resolves: #28

Signed-off-by: Kenji Brameld <kenjibrameld@gmail.com>